### PR TITLE
Support any OpenAI-compatible API, including local Ollama

### DIFF
--- a/background.js
+++ b/background.js
@@ -56,23 +56,25 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // Function to interact with OpenAI API
 async function enhanceTextWithLLM(promptId, text) {
   // Retrieve API key from storage
-  const { openaiApiKey } = await chrome.storage.sync.get(['openaiApiKey']);
+  const { openaiApiKey, llmUrl, llmModel } = await chrome.storage.sync.get(['openaiApiKey', 'llmUrl', 'llmModel']);
   
   if (!openaiApiKey) {
     throw new Error('OpenAI API key not set. Please set it in the extension options.');
   }
 
   const prompt = DEFAULT_PROMPTS.find(p => p.id === promptId).prompt;
+  const endpoint = llmUrl || 'https://api.openai.com/v1/chat/completions';
+  const model = llmModel || 'gpt-4o-mini';
 
   try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${encodeURIComponent(openaiApiKey)}`,
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: model,
         messages: [
           { role: 'system', content: 'You are a helpful assistant.' },
           { role: 'user', content: `${prompt}:\n\n${text}` }

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,8 @@
     "contextMenus"
   ],
   "host_permissions": [
+    "http://localhost:*/*",
+    "https://api.groq.com/*",
     "https://api.openai.com/*"
   ],
   "background": {

--- a/options.html
+++ b/options.html
@@ -52,6 +52,14 @@
         OpenAI API Key:
         <input type="text" id="openaiApiKey" placeholder="Enter your OpenAI API key">
     </label>
+    <label for="llmUrl">
+        LLM URL (only change if using a different provider, like Ollama or Groq):
+        <input type="text" id="llmUrl" placeholder="Enter an altenative URL for local use">
+    </label>
+    <label for="llmModel">
+        Defaults to GPT-4o-mini:
+        <input type="text" id="llmModel" placeholder="Enter an altenative LLM model">
+    </label>
     <button id="save">Save</button>
     <div id="status"></div>
     <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -1,8 +1,10 @@
 // Saves options to chrome.storage
 function saveOptions() {
     const openaiApiKey = document.getElementById('openaiApiKey').value;
+    const llmUrl = document.getElementById('llmUrl').value;
+    const llmModel = document.getElementById('llmModel').value;
     chrome.storage.sync.set(
-        { openaiApiKey },
+        { openaiApiKey, llmUrl, llmModel },
         () => {
             // Update status to let user know options were saved.
             const status = document.getElementById('status');
@@ -18,9 +20,11 @@ function saveOptions() {
 // stored in chrome.storage.
 function restoreOptions() {
     chrome.storage.sync.get(
-        { openaiApiKey: '' },
+        { openaiApiKey: '', llmUrl: '', llmModel: '' },
         (items) => {
             document.getElementById('openaiApiKey').value = items.openaiApiKey;
+            document.getElementById('llmUrl').value = items.llmUrl;
+            document.getElementById('llmModel').value = items.llmModel;
         }
     );
 }


### PR DESCRIPTION
This is a WIP to support other OpenAPI compatible endpoints, including Groq which has a free tier, or more importantly Ollama.

To fully support Ollama, there is one more step:
other origins should be configured on the Ollama server.

https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-allow-additional-web-origins-to-access-ollama

This origin should have the form: chrome-extension://<extension-id> 
(or moz for Firefox, but it would require another branch to be compatible with it)

Which means that the key should be added to the manifest: this value maintains the unique ID of an extension, or theme when it is loaded during development.

https://developer.chrome.com/docs/extensions/reference/manifest/key

Could you add it?

After that the doc should be extended a bit. 